### PR TITLE
#42 Expect messages from either source address 0x00 or 0x01

### DIFF
--- a/src-test/net/soliddesign/iumpr/bus/PacketTest.java
+++ b/src-test/net/soliddesign/iumpr/bus/PacketTest.java
@@ -144,7 +144,7 @@ public class PacketTest {
     @Test
     public void testNotEqualsObject() {
         Packet instance = Packet.create(1234, 56, 11, 22, 33);
-        assertFalse(instance.equals("Packet"));
+        assertFalse(instance.equals(new Object()));
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/bus/j1939/packets/CalibrationInformationTest.java
+++ b/src-test/net/soliddesign/iumpr/bus/j1939/packets/CalibrationInformationTest.java
@@ -63,7 +63,7 @@ public class CalibrationInformationTest {
     @Test
     public void testNotEqualsObject() {
         CalibrationInformation instance = new CalibrationInformation("id", "cvn");
-        assertFalse(instance.equals("CalibrationInformation"));
+        assertFalse(instance.equals(new Object()));
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/bus/j1939/packets/DM19CalibrationInformationPacketTest.java
+++ b/src-test/net/soliddesign/iumpr/bus/j1939/packets/DM19CalibrationInformationPacketTest.java
@@ -166,7 +166,7 @@ public class DM19CalibrationInformationPacketTest {
     public void testNotEqualsObject() {
         Packet packet = Packet.create(0xBADF, 0xFE, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
         DM19CalibrationInformationPacket instance = new DM19CalibrationInformationPacket(packet);
-        assertFalse(instance.equals("ParsedPacket"));
+        assertFalse(instance.equals(new Object()));
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/bus/j1939/packets/PerformanceRatioTest.java
+++ b/src-test/net/soliddesign/iumpr/bus/j1939/packets/PerformanceRatioTest.java
@@ -30,7 +30,7 @@ public class PerformanceRatioTest {
     @Test
     public void testEqualsObject() {
         PerformanceRatio instance = new PerformanceRatio(0, 0, 0, 0);
-        assertFalse(instance.equals("PerformanceRatio"));
+        assertFalse(instance.equals(new Object()));
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/modules/DiagnosticReadinessModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/DiagnosticReadinessModuleTest.java
@@ -215,6 +215,51 @@ public class DiagnosticReadinessModuleTest {
     }
 
     @Test
+    public void testGetDM20PacketsWithEngine1Response() {
+        final int pgn = DM20MonitorPerformanceRatioPacket.PGN;
+
+        Packet requestPacket = Packet.create(0xEA00 | 0xFF, BUS_ADDR, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0xFF)).thenReturn(requestPacket);
+
+        DM20MonitorPerformanceRatioPacket packet1 = new DM20MonitorPerformanceRatioPacket(
+                Packet.create(pgn, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
+        DM20MonitorPerformanceRatioPacket packet2 = new DM20MonitorPerformanceRatioPacket(
+                Packet.create(pgn, 0x17, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
+        DM20MonitorPerformanceRatioPacket packet3 = new DM20MonitorPerformanceRatioPacket(
+                Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
+        when(j1939.requestMultiple(DM20MonitorPerformanceRatioPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1, packet2, packet3));
+
+        String expected = "";
+        expected += "2007-12-03T10:15:30.000 Global DM20 Request" + NL;
+        expected += "10:15:30.000 18EAFFA5 00 C2 00 (TX)" + NL;
+        expected += "10:15:30.000 18C20001 11 22 33 44 55 66 77 88" + NL;
+        expected += "DM20 from Engine #2 (1):  [" + NL;
+        expected += "                                                     Num'r /  Den'r" + NL;
+        expected += "Ignition Cycles                                               8,721" + NL;
+        expected += "OBD Monitoring Conditions Encountered                        17,459" + NL;
+        expected += "]" + NL;
+        expected += "10:15:30.000 18C20017 01 02 03 04 05 06 07 08" + NL;
+        expected += "DM20 from Instrument Cluster #1 (23):  [" + NL;
+        expected += "                                                     Num'r /  Den'r" + NL;
+        expected += "Ignition Cycles                                                 513" + NL;
+        expected += "OBD Monitoring Conditions Encountered                         1,027" + NL;
+        expected += "]" + NL;
+        expected += "10:15:30.000 18C20021 10 20 30 40 50 60 70 80" + NL;
+        expected += "DM20 from Body Controller (33):  [" + NL;
+        expected += "                                                     Num'r /  Den'r" + NL;
+        expected += "Ignition Cycles                                               8,208" + NL;
+        expected += "OBD Monitoring Conditions Encountered                        16,432" + NL;
+        expected += "]" + NL;
+
+        instance.getDM20Packets(listener, true);
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0xFF);
+        verify(j1939).requestMultiple(DM20MonitorPerformanceRatioPacket.class, requestPacket);
+    }
+
+    @Test
     public void testGetDM20PacketWithNoListener() {
         final int pgn = DM20MonitorPerformanceRatioPacket.PGN;
 
@@ -336,6 +381,54 @@ public class DiagnosticReadinessModuleTest {
         expected += "10:15:30.000 18EAFFA5 00 C1 00 (TX)" + NL;
         expected += "10:15:30.000 18C10000 11 22 33 44 55 66 77 88" + NL;
         expected += "DM21 from Engine #1 (0): [" + NL;
+        expected += "  Distance Traveled While MIL is Activated:     8,721 km (5,418.978 mi)" + NL;
+        expected += "  Time Run by Engine While MIL is Activated:    26,197 minutes" + NL;
+        expected += "  Distance Since DTCs Cleared:                  17,459 km (10,848.52 mi)" + NL;
+        expected += "  Time Since DTCs Cleared:                      34,935 minutes" + NL;
+        expected += "]" + NL;
+        expected += "10:15:30.000 18C10017 01 02 03 04 05 06 07 08" + NL;
+        expected += "DM21 from Instrument Cluster #1 (23): [" + NL;
+        expected += "  Distance Traveled While MIL is Activated:     513 km (318.763 mi)" + NL;
+        expected += "  Time Run by Engine While MIL is Activated:    1,541 minutes" + NL;
+        expected += "  Distance Since DTCs Cleared:                  1,027 km (638.148 mi)" + NL;
+        expected += "  Time Since DTCs Cleared:                      2,055 minutes" + NL;
+        expected += "]" + NL;
+        expected += "10:15:30.000 18C10021 10 20 30 40 50 60 70 80" + NL;
+        expected += "DM21 from Body Controller (33): [" + NL;
+        expected += "  Distance Traveled While MIL is Activated:     8,208 km (5,100.215 mi)" + NL;
+        expected += "  Time Run by Engine While MIL is Activated:    24,656 minutes" + NL;
+        expected += "  Distance Since DTCs Cleared:                  16,432 km (10,210.371 mi)" + NL;
+        expected += "  Time Since DTCs Cleared:                      32,880 minutes" + NL;
+        expected += "]" + NL;
+
+        instance.getDM21Packets(listener, true);
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0xFF);
+        verify(j1939).requestMultiple(DM21DiagnosticReadinessPacket.class, requestPacket);
+    }
+
+    @Test
+    public void testGetDM21PacketsWithEngine1Response() {
+        final int pgn = DM21DiagnosticReadinessPacket.PGN;
+
+        Packet requestPacket = Packet.create(0xEA00 | 0xFF, BUS_ADDR, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0xFF)).thenReturn(requestPacket);
+
+        DM21DiagnosticReadinessPacket packet1 = new DM21DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
+        DM21DiagnosticReadinessPacket packet2 = new DM21DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x17, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
+        DM21DiagnosticReadinessPacket packet3 = new DM21DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
+        when(j1939.requestMultiple(DM21DiagnosticReadinessPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1, packet2, packet3));
+
+        String expected = "";
+        expected += "2007-12-03T10:15:30.000 Global DM21 Request" + NL;
+        expected += "10:15:30.000 18EAFFA5 00 C1 00 (TX)" + NL;
+        expected += "10:15:30.000 18C10001 11 22 33 44 55 66 77 88" + NL;
+        expected += "DM21 from Engine #2 (1): [" + NL;
         expected += "  Distance Traveled While MIL is Activated:     8,721 km (5,418.978 mi)" + NL;
         expected += "  Time Run by Engine While MIL is Activated:    26,197 minutes" + NL;
         expected += "  Distance Since DTCs Cleared:                  17,459 km (10,848.52 mi)" + NL;
@@ -499,6 +592,42 @@ public class DiagnosticReadinessModuleTest {
     }
 
     @Test
+    public void testGetDM26PacketsWithEngine1Response() {
+        final int pgn = DM26TripDiagnosticReadinessPacket.PGN;
+
+        Packet requestPacket = Packet.create(0xEA00 | 0xFF, BUS_ADDR, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0xFF)).thenReturn(requestPacket);
+
+        DM26TripDiagnosticReadinessPacket packet1 = new DM26TripDiagnosticReadinessPacket(
+                Packet.create(pgn, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
+        DM26TripDiagnosticReadinessPacket packet2 = new DM26TripDiagnosticReadinessPacket(
+                Packet.create(pgn, 0x17, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
+        DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(
+                Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
+        when(j1939.requestMultiple(DM26TripDiagnosticReadinessPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1, packet2, packet3));
+
+        String expected = "";
+        expected += "2007-12-03T10:15:30.000 Global DM26 Request" + NL;
+        expected += "10:15:30.000 18EAFFA5 B8 FD 00 (TX)" + NL;
+        expected += "10:15:30.000 18FDB801 11 22 33 44 55 66 77 88" + NL;
+        expected += "DM26 from Engine #2 (1): Warm-ups: 51, Time Since Engine Start: 8,721 seconds"
+                + NL;
+        expected += "10:15:30.000 18FDB817 01 02 03 04 05 06 07 08" + NL;
+        expected += "DM26 from Instrument Cluster #1 (23): Warm-ups: 3, Time Since Engine Start: 513 seconds"
+                + NL;
+        expected += "10:15:30.000 18FDB821 10 20 30 40 50 60 70 80" + NL;
+        expected += "DM26 from Body Controller (33): Warm-ups: 48, Time Since Engine Start: 8,208 seconds"
+                + NL;
+
+        instance.getDM26Packets(listener, true);
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0xFF);
+        verify(j1939).requestMultiple(DM26TripDiagnosticReadinessPacket.class, requestPacket);
+    }
+
+    @Test
     public void testGetDM26PacketsWithNoListener() {
         final int pgn = DM26TripDiagnosticReadinessPacket.PGN;
 
@@ -519,6 +648,42 @@ public class DiagnosticReadinessModuleTest {
 
         verify(j1939).createRequestPacket(pgn, 0xFF);
         verify(j1939).requestMultiple(DM26TripDiagnosticReadinessPacket.class, requestPacket);
+    }
+
+    @Test
+    public void testGetDM5PacketsEngine1Response() {
+        final int pgn = DM5DiagnosticReadinessPacket.PGN;
+
+        Packet requestPacket = Packet.create(0xEA00 | 0xFF, BUS_ADDR, pgn, pgn >> 8, pgn >> 16);
+        when(j1939.createRequestPacket(pgn, 0xFF)).thenReturn(requestPacket);
+
+        DM5DiagnosticReadinessPacket packet1 = new DM5DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88));
+        DM5DiagnosticReadinessPacket packet2 = new DM5DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x17, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
+        DM5DiagnosticReadinessPacket packet3 = new DM5DiagnosticReadinessPacket(
+                Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80));
+        when(j1939.requestMultiple(DM5DiagnosticReadinessPacket.class, requestPacket))
+                .thenReturn(Stream.of(packet1, packet2, packet3));
+
+        String expected = "";
+        expected += "2007-12-03T10:15:30.000 Global DM5 Request" + NL;
+        expected += "10:15:30.000 18EAFFA5 CE FE 00 (TX)" + NL;
+        expected += "10:15:30.000 18FECE01 11 22 33 44 55 66 77 88" + NL;
+        expected += "DM5 from Engine #2 (1): OBD Compliance: Reserved for SAE/Unknown (51), Active Codes: 17, Previously Active Codes: 34"
+                + NL;
+        expected += "10:15:30.000 18FECE17 01 02 03 04 05 06 07 08" + NL;
+        expected += "DM5 from Instrument Cluster #1 (23): OBD Compliance: OBD and OBD II (3), Active Codes: 1, Previously Active Codes: 2"
+                + NL;
+        expected += "10:15:30.000 18FECE21 10 20 30 40 50 60 70 80" + NL;
+        expected += "DM5 from Body Controller (33): OBD Compliance: Reserved for SAE/Unknown (48), Active Codes: 16, Previously Active Codes: 32"
+                + NL;
+
+        instance.getDM5Packets(listener, true);
+        assertEquals(expected, listener.getResults());
+
+        verify(j1939).createRequestPacket(pgn, 0xFF);
+        verify(j1939).requestMultiple(DM5DiagnosticReadinessPacket.class, requestPacket);
     }
 
     @Test
@@ -670,7 +835,7 @@ public class DiagnosticReadinessModuleTest {
         packets.add(new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80)));
 
-        assertEquals(0, DiagnosticReadinessModule.getIgnitionCycles(packets));
+        assertEquals(8208, DiagnosticReadinessModule.getIgnitionCycles(packets));
     }
 
     @Test
@@ -683,6 +848,12 @@ public class DiagnosticReadinessModuleTest {
         packets.add(new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80)));
 
+        assertEquals(8208, DiagnosticReadinessModule.getIgnitionCycles(packets));
+    }
+
+    @Test
+    public void testGetIgnitionCyclesWithoutPackets() {
+        List<DM20MonitorPerformanceRatioPacket> packets = new ArrayList<>();
         assertEquals(-1, DiagnosticReadinessModule.getIgnitionCycles(packets));
     }
 
@@ -698,7 +869,7 @@ public class DiagnosticReadinessModuleTest {
         packets.add(new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80)));
 
-        assertEquals(0, DiagnosticReadinessModule.getOBDCounts(packets));
+        assertEquals(16432, DiagnosticReadinessModule.getOBDCounts(packets));
     }
 
     @Test
@@ -711,6 +882,12 @@ public class DiagnosticReadinessModuleTest {
         packets.add(new DM20MonitorPerformanceRatioPacket(
                 Packet.create(pgn, 0x21, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80)));
 
+        assertEquals(16432, DiagnosticReadinessModule.getOBDCounts(packets));
+    }
+
+    @Test
+    public void testGetOBDCountsWithoutPackets() {
+        List<DM20MonitorPerformanceRatioPacket> packets = new ArrayList<>();
         assertEquals(-1, DiagnosticReadinessModule.getOBDCounts(packets));
     }
 

--- a/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
@@ -385,7 +385,7 @@ public class ReportFileModuleTest {
     }
 
     @Test
-    public void testRatioCountersOnlyComeFromEngine() throws Exception {
+    public void testRatioCountersUseMax() throws Exception {
         Writer writer = Files.newBufferedWriter(file.toPath(), StandardOpenOption.WRITE);
         writer.write(
                 "2017-02-11T16:42:21.889 18D30000 96 BF DC 40 50 42 54 35 4D 50 52 33 20 20 20 20 20 20 20 20 20 20 20 20"
@@ -394,6 +394,8 @@ public class ReportFileModuleTest {
         writer.write("2017-02-11T16:44:12.164 Vehicle Identification from Engine #1 (0): ASDFGHJKLASDFGHJKL" + NL);
         writer.write("2017-03-05T12:21:43.838 Diagnostic Trouble Codes were successfully cleared." + NL);
         writer.write("2017-03-05T12:21:45.090 18FECE00 00 00 14 37 E0 1E E0 1E" + NL);
+        writer.write("2017-03-05T12:21:46.090 18FECE01 00 00 14 37 E0 1E E0 1E" + NL);
+        writer.write("2017-03-05T12:21:46.190 18FECE17 00 00 14 37 E0 1E E0 1E" + NL);
         writer.write("  Time Since DTCs Cleared:                      14 minutes" + NL);
         writer.write("2017-03-05T12:21:47.610 18C20000 0C 00 01 00 CA 14 F8 00 00 01 00" + NL);
         writer.write("2017-03-05T12:21:48.610 18C20055 1C 00 11 00 CB 14 F8 00 00 01 00" + NL);
@@ -414,8 +416,8 @@ public class ReportFileModuleTest {
         assertEquals(16, instance.getInitialMonitors().size());
         assertEquals(LocalDateTime.parse("2017-03-05T12:21:47.610"), instance.getInitialRatiosTime());
         assertEquals(2, instance.getInitialRatios().size());
-        assertEquals(12, instance.getInitialIgnitionCycles());
-        assertEquals(1, instance.getInitialOBDCounts());
+        assertEquals(28, instance.getInitialIgnitionCycles());
+        assertEquals(17, instance.getInitialOBDCounts());
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/ui/status/InfoTableTest.java
+++ b/src-test/net/soliddesign/iumpr/ui/status/InfoTableTest.java
@@ -118,16 +118,16 @@ public class InfoTableTest {
 
         DM20MonitorPerformanceRatioPacket packet2 = mock(DM20MonitorPerformanceRatioPacket.class);
         when(packet2.getSourceAddress()).thenReturn(55);
-        when(packet2.getIgnitionCycles()).thenReturn(50);
-        when(packet2.getOBDConditionsCount()).thenReturn(5);
+        when(packet2.getIgnitionCycles()).thenReturn(101);
+        when(packet2.getOBDConditionsCount()).thenReturn(16);
 
         instance.process(packet2);
 
-        assertEquals(100.0, instance.getValueAt(2, 1));
-        validateRowBackground(instance.getBackground(), 2);
-        assertEquals(15.0, instance.getValueAt(3, 1));
-        validateRowBackground(instance.getBackground(), 3);
-        assertFalse(tableUpdated);
+        assertEquals(101.0, instance.getValueAt(2, 1));
+        validateRowBackground(Color.GREEN, 2);
+        assertEquals(16.0, instance.getValueAt(3, 1));
+        validateRowBackground(Color.GREEN, 3);
+        assertTrue(tableUpdated);
     }
 
     @Test

--- a/src/net/soliddesign/iumpr/bus/j1939/J1939.java
+++ b/src/net/soliddesign/iumpr/bus/j1939/J1939.java
@@ -80,6 +80,11 @@ public class J1939 {
     public static final int ENGINE_ADDR = 0x00;
 
     /**
+     * The 'other' address for an engine
+     */
+    public static final int ENGINE_ADDR_1 = 0x01;
+
+    /**
      * The global source address for broadcast
      */
     public static final int GLOBAL_ADDR = 0xFF;

--- a/src/net/soliddesign/iumpr/bus/simulated/Engine.java
+++ b/src/net/soliddesign/iumpr/bus/simulated/Engine.java
@@ -157,7 +157,7 @@ public class Engine implements AutoCloseable {
                 () -> Packet.create(0xFDB8, ADDR, 0x00, 0x00, 0x00, 0x37, 0xC0, 0x1E, 0xC0, 0x1E));
         // DM20
         sim.response(p -> isRequestFor(0xC200, p),
-                () -> Packet.create(0xC200, ADDR,
+                () -> Packet.create(0xC200, 0x01,
                         0x0C, 0x00, // Ignition Cycles
                         demCount & 0xFF, (demCount >> 8) & 0xFF, // OBD Counts
                         // Monitors 3 Bytes SPN, 2 bytes: Num, Dem

--- a/src/net/soliddesign/iumpr/bus/simulated/Sim.java
+++ b/src/net/soliddesign/iumpr/bus/simulated/Sim.java
@@ -4,7 +4,6 @@
 package net.soliddesign.iumpr.bus.simulated;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -13,7 +12,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import net.soliddesign.iumpr.IUMPR;
@@ -49,11 +47,7 @@ public class Sim implements AutoCloseable {
         Stream<Packet> stream = bus.read(365, TimeUnit.DAYS);
         exec.submit(() -> {
             stream.forEach(packet -> {
-                List<Boolean> list = responses.stream()
-                        .map(c -> c.apply(packet))
-                        .filter(p -> p)
-                        .collect(Collectors.toList());
-                responses.removeAll(list);
+                responses.stream().forEach(c -> c.apply(packet));
             });
         });
     }
@@ -61,27 +55,6 @@ public class Sim implements AutoCloseable {
     @Override
     public void close() {
         exec.shutdown();
-    }
-
-    /**
-     * Sends a response once with a {@link Packet}
-     *
-     * @param predicate
-     *            the {@link Predicate} used to determine if the {@link Packet}
-     *            should be sent
-     * @param supplier
-     *            the {@link Supplier} of the {@link Packet}
-     * @return this
-     */
-    public Sim respondOnce(Predicate<Packet> predicate, Supplier<Packet> supplier) {
-        responses.add(packet -> {
-            if (predicate.test(packet)) {
-                send(supplier);
-                return true;
-            }
-            return false;
-        });
-        return this;
     }
 
     /**

--- a/src/net/soliddesign/iumpr/modules/ReportFileModule.java
+++ b/src/net/soliddesign/iumpr/modules/ReportFileModule.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 
 import net.soliddesign.iumpr.IUMPR;
 import net.soliddesign.iumpr.bus.Packet;
-import net.soliddesign.iumpr.bus.j1939.J1939;
 import net.soliddesign.iumpr.bus.j1939.packets.DM19CalibrationInformationPacket;
 import net.soliddesign.iumpr.bus.j1939.packets.DM19CalibrationInformationPacket.CalibrationInformation;
 import net.soliddesign.iumpr.bus.j1939.packets.DM20MonitorPerformanceRatioPacket;
@@ -138,7 +137,7 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
     /**
      * The initial value for the number of ignition cycles
      */
-    private int initialIgnitionCycles;
+    private int initialIgnitionCycles = Integer.MIN_VALUE;
 
     /**
      * The {@link MonitoredSystem}s that were first captured in the report file
@@ -153,7 +152,7 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
     /**
      * The initial value for the Number of OBD Monitoring Conditions Encountered
      */
-    private int initialOBDCounts;
+    private int initialOBDCounts = Integer.MIN_VALUE;
 
     /**
      * The {@link PerformanceRatio} that were first captured in the report file
@@ -330,7 +329,7 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
                 // There's a sweet spot in the data plate report section after
                 // the codes are cleared where the DM5s are valid
                 initialMonitors.addAll(packet.getMonitoredSystems());
-                if (packet.getSourceAddress() == J1939.ENGINE_ADDR) {
+                if (initialMonitorsTime == null) {
                     initialMonitorsTime = parseDateTime(line);
                 }
             }
@@ -353,10 +352,18 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
                 // There's a sweet spot in the data plate report section after
                 // the codes are cleared where the DM20s are valid
                 initialRatios.addAll(packet.getRatios());
-                if (packet.getSourceAddress() == J1939.ENGINE_ADDR) {
+                if (initialRatiosTime == null) {
                     initialRatiosTime = parseDateTime(line);
-                    initialIgnitionCycles = packet.getIgnitionCycles();
-                    initialOBDCounts = packet.getOBDConditionsCount();
+                }
+
+                int ignitionCycles = packet.getIgnitionCycles();
+                if (initialIgnitionCycles < ignitionCycles) {
+                    initialIgnitionCycles = ignitionCycles;
+                }
+
+                int obdCounts = packet.getOBDConditionsCount();
+                if (initialOBDCounts < obdCounts) {
+                    initialOBDCounts = obdCounts;
                 }
             }
             return true;


### PR DESCRIPTION
This changes the logic to not rely on just source address 0 for information.  We will use the highest value for the ignition cycles or OBD counts.  We will use the first monitors packet or ratios packet as the initial time.  We will re-try the requests for DM5, DM20, DM21 and DM26 until we get a response from either source address 0 or source address 1.  This will also fix #45, fix #47 and fix #42