### PR TITLE
Fix #74 - Dates can be inconsistent.

### DIFF
--- a/src-test/net/soliddesign/iumpr/controllers/CollectResultsControllerTest.java
+++ b/src-test/net/soliddesign/iumpr/controllers/CollectResultsControllerTest.java
@@ -320,14 +320,14 @@ public class CollectResultsControllerTest {
 
         when(dateTimeModule.getDateTime()).thenReturn("CurrentTime");
 
-        LocalDateTime monitorTime = LocalDateTime.now();
+        LocalDateTime monitorTime = LocalDateTime.now().minusSeconds(2);
         when(reportFileModule.getInitialMonitorsTime()).thenReturn(monitorTime);
         when(dateTimeModule.format(monitorTime)).thenReturn("MonitorTime");
 
         Set<MonitoredSystem> initialSystems = new HashSet<>();
         when(reportFileModule.getInitialMonitors()).thenReturn(initialSystems);
 
-        LocalDateTime ratioTime = LocalDateTime.now();
+        LocalDateTime ratioTime = LocalDateTime.now().plusSeconds(2);
         when(reportFileModule.getInitialRatiosTime()).thenReturn(ratioTime);
         when(dateTimeModule.format(ratioTime)).thenReturn("RatioTime");
 

--- a/src-test/net/soliddesign/iumpr/controllers/MonitorCompletionControllerTest.java
+++ b/src-test/net/soliddesign/iumpr/controllers/MonitorCompletionControllerTest.java
@@ -238,7 +238,7 @@ public class MonitorCompletionControllerTest {
                 .thenReturn(true);
         when(reportFileModule.getMinutesSinceCodeClear()).thenReturn((double) 1234);
 
-        LocalDateTime monitorTime = LocalDateTime.now();
+        LocalDateTime monitorTime = LocalDateTime.now().minusSeconds(2);
         when(reportFileModule.getInitialMonitorsTime()).thenReturn(monitorTime);
         when(dateTimeModule.format(monitorTime)).thenReturn("MonitorTime");
 
@@ -248,7 +248,7 @@ public class MonitorCompletionControllerTest {
         Set<MonitoredSystem> lastSystems = new HashSet<>();
         when(monitorTrackingModule.getLastSystems()).thenReturn(lastSystems);
 
-        LocalDateTime ratioTime = LocalDateTime.now();
+        LocalDateTime ratioTime = LocalDateTime.now().plusSeconds(2);
         when(reportFileModule.getInitialRatiosTime()).thenReturn(ratioTime);
         when(dateTimeModule.format(ratioTime)).thenReturn("RatioTime");
 

--- a/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
@@ -628,7 +628,13 @@ public class ReportFileModuleTest {
         writer.write("2017-03-05T12:21:45.090 18FECE00 00 00 14 37 E0 1E E0 1E" + NL);
         writer.write("  Time Since DTCs Cleared:                      14 minutes" + NL);
         writer.write("2017-03-05T12:21:47.610 18C20000 0C 00 01 00 CA 14 F8 00 00 01 00" + NL);
-        writer.write("2017-03-05T12:21:56.495 IUMPR Data Collection Tool Data Plate Report END OF REPORT");
+        // The following lines tests an out of order date sequence from packets
+        // capture during monitor completion.
+        writer.write("2017-03-05T12:43:53.076 Begin Tracking Monitor Completion Status" + NL);
+        writer.write("12:46:55.854 DM5 Packet(s) Received" + NL);
+        writer.write("12:46:45.933 18FECE00 00 00 14 37 E0 1E E0 1E" + NL);
+        writer.write("2017-03-05T12:54:38.658 End Tracking Monitor Completion Status. 65 Total Cycles." + NL);
+        writer.write("2017-03-05T13:21:56.495 IUMPR Data Collection Tool Data Plate Report END OF REPORT");
         writer.close();
 
         instance.setReportFile(listener, file, false);

--- a/src-test/net/soliddesign/iumpr/system/SystemTest.java
+++ b/src-test/net/soliddesign/iumpr/system/SystemTest.java
@@ -6,6 +6,7 @@ package net.soliddesign.iumpr.system;
 import static net.soliddesign.iumpr.IUMPR.NL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -20,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -552,16 +552,20 @@ public class SystemTest {
 
         while (view.getEnabled() == startingValue) {
             if (System.currentTimeMillis() - start > maxTime) {
-                Assert.assertEquals("transition: " + startingValue + " -> " + endingValue, startingValue,
-                        view.getEnabled());
+                assertEquals("transition: " + startingValue + " -> " + endingValue, startingValue, view.getEnabled());
+                if (System.currentTimeMillis() - start > maxTime * 2) {
+                    fail("Timeout waiting for starting value to change");
+                }
             }
             Thread.sleep(100);
         }
 
         while (view.getEnabled() != endingValue) {
             if (System.currentTimeMillis() - start > maxTime) {
-                Assert.assertEquals("transition: " + startingValue + " -> " + endingValue, endingValue,
-                        view.getEnabled());
+                assertEquals("transition: " + startingValue + " -> " + endingValue, endingValue, view.getEnabled());
+                if (System.currentTimeMillis() - start > maxTime * 2) {
+                    fail("Timeout waiting for ending value to change");
+                }
             }
             Thread.sleep(100);
         }


### PR DESCRIPTION
The problem came from the reporting during the Monitor Completion Phase.  During this phase packets are collected and periodically written to the report.  When the packets are written to the report they are accompanied by a header which includes the current time, but the packet includes the time it was received.  That causes the times in the file to be out of order.

Since there are files already in the field with this problem, an exception case was added to the ReportFileModule that will not look for date inconsistencies in the Monitor Completion section of the report. A unit test case was adjusted to test for this issue.

Additionally, some unit tests were fixed that were initially not completing due to an incomplete environmental setup.