### PR TITLE
Fix #77 - DiagnosticReadinessPacket.isOBDModule() is wrong.

### DIFF
--- a/src-test/net/soliddesign/iumpr/bus/j1939/packets/DM26TripDiagnosticReadinessPacketTest.java
+++ b/src-test/net/soliddesign/iumpr/bus/j1939/packets/DM26TripDiagnosticReadinessPacketTest.java
@@ -5,9 +5,8 @@ package net.soliddesign.iumpr.bus.j1939.packets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Objects;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -19,45 +18,50 @@ import net.soliddesign.iumpr.bus.Packet;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-public class DM26TripDiagnosticReadinessPacketTest {
+public class DM26TripDiagnosticReadinessPacketTest extends DiagnosticReadinessPacketTest {
 
-    @Test
-    public void testEqualsAndHashCode() {
-        Packet packet = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        DM26TripDiagnosticReadinessPacket instance1 = new DM26TripDiagnosticReadinessPacket(packet);
-        DM26TripDiagnosticReadinessPacket instance2 = new DM26TripDiagnosticReadinessPacket(packet);
+    @Override
+    protected DiagnosticReadinessPacket createInstance(Packet packet) {
+        return new DM26TripDiagnosticReadinessPacket(packet);
+    }
 
-        assertTrue(instance1.equals(instance2));
-        assertTrue(instance2.equals(instance1));
-        assertTrue(instance1.hashCode() == instance2.hashCode());
+    @Override
+    protected MonitoredSystemStatus findStatus(boolean enabled, boolean complete) {
+        return MonitoredSystemStatus.findStatus(false, enabled, complete);
     }
 
     @Test
-    public void testEqualsAndHashCodeSelf() {
-        Packet packet = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        DM26TripDiagnosticReadinessPacket instance = new DM26TripDiagnosticReadinessPacket(packet);
-        assertTrue(instance.equals(instance));
-        assertTrue(instance.hashCode() == instance.hashCode());
-    }
-
-    @Test
-    public void testEqualsContinouslyMonitoredSystems() {
-        Packet packet1 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x00, 0x55, 0x66, 0x77, 0x88);
-        DM26TripDiagnosticReadinessPacket instance1 = new DM26TripDiagnosticReadinessPacket(packet1);
-        for (int i = 1; i < 255; i++) {
-            Packet packet2 = Packet.create(0, 0, 0x11, 0x22, 0x33, i, 0x55, 0x66, 0x77, 0x88);
-            DM26TripDiagnosticReadinessPacket instance2 = new DM26TripDiagnosticReadinessPacket(packet2);
-            boolean equal = Objects.equals(instance1.getContinuouslyMonitoredSystems(),
-                    instance2.getContinuouslyMonitoredSystems());
-            assertEquals("Failed with packet " + packet2, equal, instance1.equals(instance2));
+    public void test0xFF() {
+        DiagnosticReadinessPacket instance = createInstance(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+        {
+            List<MonitoredSystem> systems = instance.getContinuouslyMonitoredSystems();
+            for (MonitoredSystem system : systems) {
+                assertEquals(system.getName() + " is wrong", findStatus(true, false), system.getStatus());
+            }
+        }
+        {
+            List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
+            for (MonitoredSystem system : systems) {
+                assertEquals(system.getName() + " is wrong", findStatus(true, false), system.getStatus());
+            }
         }
     }
 
     @Test
-    public void testEqualsWithObject() {
-        Packet packet = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        DM26TripDiagnosticReadinessPacket instance = new DM26TripDiagnosticReadinessPacket(packet);
-        assertFalse(instance.equals(new Object()));
+    public void test0xFFWith0x05AsThirdByte() {
+        DiagnosticReadinessPacket instance = createInstance(0xFF, 0xFF, 0x05, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+        {
+            List<MonitoredSystem> systems = instance.getContinuouslyMonitoredSystems();
+            for (MonitoredSystem system : systems) {
+                assertEquals(system.getName() + " is wrong", findStatus(true, false), system.getStatus());
+            }
+        }
+        {
+            List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
+            for (MonitoredSystem system : systems) {
+                assertEquals(system.getName() + " is wrong", findStatus(true, false), system.getStatus());
+            }
+        }
     }
 
     @Test
@@ -100,28 +104,6 @@ public class DM26TripDiagnosticReadinessPacketTest {
         Packet packet = Packet.create(0, 0, 11, 22, 0xFF, 44, 55, 66, 77, 88);
         DM26TripDiagnosticReadinessPacket instance = new DM26TripDiagnosticReadinessPacket(packet);
         assertEquals((byte) 0xFF, instance.getWarmUpsSinceClear());
-    }
-
-    @Test
-    public void testNotEqualsNonContinouslyMonitoredSystemsCompleted() {
-        Packet packet1 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DM26TripDiagnosticReadinessPacket instance1 = new DM26TripDiagnosticReadinessPacket(packet1);
-        for (int i = 1; i < 255; i++) {
-            Packet packet2 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, 0xFF, 0xFF, i, i);
-            DM26TripDiagnosticReadinessPacket instance2 = new DM26TripDiagnosticReadinessPacket(packet2);
-            assertFalse("Failed with packet " + packet2, instance1.equals(instance2));
-        }
-    }
-
-    @Test
-    public void testNotEqualsNonContinouslyMonitoredSystemsSupported() {
-        Packet packet1 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DM26TripDiagnosticReadinessPacket instance1 = new DM26TripDiagnosticReadinessPacket(packet1);
-        for (int i = 1; i < 255; i++) {
-            Packet packet2 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, i, i, 0x77, 0x88);
-            DM26TripDiagnosticReadinessPacket instance2 = new DM26TripDiagnosticReadinessPacket(packet2);
-            assertFalse("Failed with packet " + packet2, instance1.equals(instance2));
-        }
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/bus/j1939/packets/DiagnosticReadinessPacketTest.java
+++ b/src-test/net/soliddesign/iumpr/bus/j1939/packets/DiagnosticReadinessPacketTest.java
@@ -3,7 +3,6 @@
  */
 package net.soliddesign.iumpr.bus.j1939.packets;
 
-import static net.soliddesign.iumpr.bus.j1939.packets.MonitoredSystemStatus.findStatus;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -22,73 +21,37 @@ import net.soliddesign.iumpr.bus.Packet;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-public class DiagnosticReadinessPacketTest {
+public abstract class DiagnosticReadinessPacketTest {
 
-    private static DiagnosticReadinessPacket createInstance(int[] data) {
-        Packet packet = Packet.create(0, 0, data);
-        DiagnosticReadinessPacket instance = new DiagnosticReadinessPacket(packet);
-        return instance;
+    protected DiagnosticReadinessPacket createInstance(int... data) {
+        return createInstance(Packet.create(0, 0, data));
     }
+
+    protected abstract DiagnosticReadinessPacket createInstance(Packet packet);
+
+    protected abstract MonitoredSystemStatus findStatus(boolean enabled, boolean complete);
 
     @Test
     public void test0x00() {
-        Packet packet = Packet.create(0, 0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
-        DiagnosticReadinessPacket instance = new DiagnosticReadinessPacket(packet);
+        DiagnosticReadinessPacket instance = createInstance(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
         {
             List<MonitoredSystem> systems = instance.getContinuouslyMonitoredSystems();
             for (MonitoredSystem system : systems) {
-                assertEquals(system.getName() + " is wrong", findStatus(false, false, true), system.getStatus());
+                assertEquals(system.getName() + " is wrong", findStatus(false, true), system.getStatus());
             }
         }
         {
             List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
             for (MonitoredSystem system : systems) {
-                assertEquals(system.getName() + " is wrong", findStatus(false, false, true), system.getStatus());
-            }
-        }
-    }
-
-    @Test
-    public void test0xFF() {
-        Packet packet = Packet.create(0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-        DiagnosticReadinessPacket instance = new DiagnosticReadinessPacket(packet);
-        {
-            List<MonitoredSystem> systems = instance.getContinuouslyMonitoredSystems();
-            for (MonitoredSystem system : systems) {
-                assertEquals(system.getName() + " is wrong", findStatus(false, false, false), system.getStatus());
-            }
-        }
-        {
-            List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
-            for (MonitoredSystem system : systems) {
-                assertEquals(system.getName() + " is wrong", findStatus(false, false, false), system.getStatus());
-            }
-        }
-    }
-
-    @Test
-    public void test0xFFWithNoOBD() {
-        Packet packet = Packet.create(0, 0, 0xFF, 0xFF, 0x05, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-        DiagnosticReadinessPacket instance = new DiagnosticReadinessPacket(packet);
-        {
-            List<MonitoredSystem> systems = instance.getContinuouslyMonitoredSystems();
-            for (MonitoredSystem system : systems) {
-                assertEquals(system.getName() + " is wrong", findStatus(false, false, false), system.getStatus());
-            }
-        }
-        {
-            List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
-            for (MonitoredSystem system : systems) {
-                assertEquals(system.getName() + " is wrong", findStatus(false, false, false), system.getStatus());
+                assertEquals(system.getName() + " is wrong", findStatus(false, true), system.getStatus());
             }
         }
     }
 
     @Test
     public void testEqualsAndHashCode() {
-        Packet packet = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        DiagnosticReadinessPacket instance1 = new DiagnosticReadinessPacket(packet);
-        DiagnosticReadinessPacket instance2 = new DiagnosticReadinessPacket(packet);
+        DiagnosticReadinessPacket instance1 = createInstance(0x11, 0x22, 0x33, 0x00, 0x55, 0x66, 0x77, 0x88);
+        DiagnosticReadinessPacket instance2 = createInstance(0x11, 0x22, 0x33, 0x00, 0x55, 0x66, 0x77, 0x88);
 
         assertTrue(instance1.equals(instance2));
         assertTrue(instance2.equals(instance1));
@@ -97,57 +60,54 @@ public class DiagnosticReadinessPacketTest {
 
     @Test
     public void testEqualsAndHashCodeSelf() {
-        Packet packet = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        DiagnosticReadinessPacket instance = new DiagnosticReadinessPacket(packet);
+        DiagnosticReadinessPacket instance = createInstance(
+                new int[] { 0x11, 0x22, 0x33, 0x00, 0x55, 0x66, 0x77, 0x88 });
         assertTrue(instance.equals(instance));
         assertTrue(instance.hashCode() == instance.hashCode());
     }
 
     @Test
     public void testEqualsContinouslyMonitoredSystems() {
-        Packet packet1 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x00, 0x55, 0x66, 0x77, 0x88);
-        DiagnosticReadinessPacket instance1 = new DiagnosticReadinessPacket(packet1);
+        DiagnosticReadinessPacket instance1 = createInstance(0x11, 0x22, 0x33, 0x00, 0x55, 0x66, 0x77, 0x88);
         for (int i = 1; i < 255; i++) {
-            Packet packet2 = Packet.create(0, 0, 0x11, 0x22, 0x33, i, 0x55, 0x66, 0x77, 0x88);
-            DiagnosticReadinessPacket instance2 = new DiagnosticReadinessPacket(packet2);
+            DiagnosticReadinessPacket instance2 = createInstance(0x11, 0x22, 0x33, i, 0x55, 0x66, 0x77, 0x88);
             boolean equal = Objects.equals(instance1.getContinuouslyMonitoredSystems(),
                     instance2.getContinuouslyMonitoredSystems());
-            assertEquals("Failed with packet " + packet2, equal, instance1.equals(instance2));
+            assertEquals("Failed at index " + i, equal, instance1.equals(instance2));
         }
     }
 
     @Test
     public void testEqualsWithObject() {
-        Packet packet = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        DiagnosticReadinessPacket instance = new DiagnosticReadinessPacket(packet);
+        DiagnosticReadinessPacket instance = createInstance(0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
         assertFalse(instance.equals(new Object()));
     }
 
     @Test
     public void testGetContinouslyMonitoredSystemsComprehensiveComponentMonitoring() {
         final String name = "Comprehensive component   ";
-        validateContinouslyMonitoredSystems(name, 0, 0x00, findStatus(false, false, true));
-        validateContinouslyMonitoredSystems(name, 0, 0x04, findStatus(false, true, true));
-        validateContinouslyMonitoredSystems(name, 0, 0x40, findStatus(false, false, false));
-        validateContinouslyMonitoredSystems(name, 0, 0x44, findStatus(false, true, false));
+        validateContinouslyMonitoredSystems(name, 0, 0x00, findStatus(false, true));
+        validateContinouslyMonitoredSystems(name, 0, 0x04, findStatus(true, true));
+        validateContinouslyMonitoredSystems(name, 0, 0x40, findStatus(false, false));
+        validateContinouslyMonitoredSystems(name, 0, 0x44, findStatus(true, false));
     }
 
     @Test
     public void testGetContinouslyMonitoredSystemsFuelSystemMonitoring() {
         final String name = "Fuel System               ";
-        validateContinouslyMonitoredSystems(name, 1, 0x00, findStatus(false, false, true));
-        validateContinouslyMonitoredSystems(name, 1, 0x02, findStatus(false, true, true));
-        validateContinouslyMonitoredSystems(name, 1, 0x20, findStatus(false, false, false));
-        validateContinouslyMonitoredSystems(name, 1, 0x22, findStatus(false, true, false));
+        validateContinouslyMonitoredSystems(name, 1, 0x00, findStatus(false, true));
+        validateContinouslyMonitoredSystems(name, 1, 0x02, findStatus(true, true));
+        validateContinouslyMonitoredSystems(name, 1, 0x20, findStatus(false, false));
+        validateContinouslyMonitoredSystems(name, 1, 0x22, findStatus(true, false));
     }
 
     @Test
     public void testGetContinouslyMonitoredSystemsMisfireMonitoring() {
         final String name = "Misfire                   ";
-        validateContinouslyMonitoredSystems(name, 2, 0x00, findStatus(false, false, true));
-        validateContinouslyMonitoredSystems(name, 2, 0x01, findStatus(false, true, true));
-        validateContinouslyMonitoredSystems(name, 2, 0x10, findStatus(false, false, false));
-        validateContinouslyMonitoredSystems(name, 2, 0x11, findStatus(false, true, false));
+        validateContinouslyMonitoredSystems(name, 2, 0x00, findStatus(false, true));
+        validateContinouslyMonitoredSystems(name, 2, 0x01, findStatus(true, true));
+        validateContinouslyMonitoredSystems(name, 2, 0x10, findStatus(false, false));
+        validateContinouslyMonitoredSystems(name, 2, 0x11, findStatus(true, false));
     }
 
     @Test
@@ -181,41 +141,33 @@ public class DiagnosticReadinessPacketTest {
 
     @Test
     public void testNotEqualsNonContinouslyMonitoredSystemsCompleted() {
-        Packet packet1 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DiagnosticReadinessPacket instance1 = new DiagnosticReadinessPacket(packet1);
+        DiagnosticReadinessPacket instance1 = createInstance(0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
         for (int i = 1; i < 255; i++) {
-            Packet packet2 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, 0xFF, 0xFF, i, i);
-            DiagnosticReadinessPacket instance2 = new DiagnosticReadinessPacket(packet2);
-            assertFalse("Failed with packet " + packet2, instance1.equals(instance2));
+            DiagnosticReadinessPacket instance2 = createInstance(0x11, 0x22, 0x33, 0x44, 0xFF, 0xFF, i, i);
+            assertFalse("Failed with index " + i, instance1.equals(instance2));
         }
     }
 
     @Test
     public void testNotEqualsNonContinouslyMonitoredSystemsSupported() {
-        Packet packet1 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DiagnosticReadinessPacket instance1 = new DiagnosticReadinessPacket(packet1);
+        DiagnosticReadinessPacket instance1 = createInstance(0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
         for (int i = 1; i < 255; i++) {
-            Packet packet2 = Packet.create(0, 0, 0x11, 0x22, 0x33, 0x44, i, i, 0x77, 0x88);
-            DiagnosticReadinessPacket instance2 = new DiagnosticReadinessPacket(packet2);
-            assertFalse("Failed with packet " + packet2, instance1.equals(instance2));
+            DiagnosticReadinessPacket instance2 = createInstance(0x11, 0x22, 0x33, 0x44, i, i, 0x77, 0x88);
+            assertFalse("Failed with index " + i, instance1.equals(instance2));
         }
     }
 
     @Test
     public void testNotEqualsSourceAddress() {
-        Packet packet1 = Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88);
-        Packet packet2 = Packet.create(0, 99, 11, 22, 33, 44, 55, 66, 77, 88);
-        DiagnosticReadinessPacket instance1 = new DiagnosticReadinessPacket(packet1);
-        DiagnosticReadinessPacket instance2 = new DiagnosticReadinessPacket(packet2);
+        DiagnosticReadinessPacket instance1 = createInstance(Packet.create(0, 0, 11, 22, 33, 44, 55, 66, 77, 88));
+        DiagnosticReadinessPacket instance2 = createInstance(Packet.create(0, 99, 11, 22, 33, 44, 55, 66, 77, 88));
 
         assertFalse(instance1.equals(instance2));
         assertFalse(instance2.equals(instance1));
     }
 
     private void validateContinouslyMonitoredSystems(String name, int index, int value, MonitoredSystemStatus status) {
-        int[] data = new int[] { 0, 0, 0, value, 0, 0, 0, 0 };
-
-        DiagnosticReadinessPacket instance = createInstance(data);
+        DiagnosticReadinessPacket instance = createInstance(0, 0, 0, value, 0, 0, 0, 0);
 
         final List<MonitoredSystem> systems = instance.getContinuouslyMonitoredSystems();
         assertEquals(3, systems.size());
@@ -227,24 +179,22 @@ public class DiagnosticReadinessPacketTest {
     }
 
     private void validateNonContinouslyMonitoredSystem1(final String name, final int index, final int mask) {
-        validateNonContinouslyMonitoredSystems1(name, index, 0x00, 0x00, findStatus(false, false, true));
-        validateNonContinouslyMonitoredSystems1(name, index, 0x00, mask, findStatus(false, false, false));
-        validateNonContinouslyMonitoredSystems1(name, index, mask, 0x00, findStatus(false, true, true));
-        validateNonContinouslyMonitoredSystems1(name, index, mask, mask, findStatus(false, true, false));
+        validateNonContinouslyMonitoredSystems1(name, index, 0x00, 0x00, findStatus(false, true));
+        validateNonContinouslyMonitoredSystems1(name, index, 0x00, mask, findStatus(false, false));
+        validateNonContinouslyMonitoredSystems1(name, index, mask, 0x00, findStatus(true, true));
+        validateNonContinouslyMonitoredSystems1(name, index, mask, mask, findStatus(true, false));
     }
 
     private void validateNonContinouslyMonitoredSystem2(final String name, final int index, final int mask) {
-        validateNonContinouslyMonitoredSystems2(name, index, 0x00, 0x00, findStatus(false, false, true));
-        validateNonContinouslyMonitoredSystems2(name, index, 0x00, mask, findStatus(false, false, false));
-        validateNonContinouslyMonitoredSystems2(name, index, mask, 0x00, findStatus(false, true, true));
-        validateNonContinouslyMonitoredSystems2(name, index, mask, mask, findStatus(false, true, false));
+        validateNonContinouslyMonitoredSystems2(name, index, 0x00, 0x00, findStatus(false, true));
+        validateNonContinouslyMonitoredSystems2(name, index, 0x00, mask, findStatus(false, false));
+        validateNonContinouslyMonitoredSystems2(name, index, mask, 0x00, findStatus(true, true));
+        validateNonContinouslyMonitoredSystems2(name, index, mask, mask, findStatus(true, false));
     }
 
     private void validateNonContinouslyMonitoredSystems1(String name, int index, int lowerByte, int upperByte,
             MonitoredSystemStatus status) {
-        int[] data = new int[] { 0, 0, 0, 0, lowerByte, 0, upperByte, 0 };
-
-        DiagnosticReadinessPacket instance = createInstance(data);
+        DiagnosticReadinessPacket instance = createInstance(0, 0, 0, 0, lowerByte, 0, upperByte, 0);
 
         final List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
         assertEquals(13, systems.size());
@@ -256,9 +206,7 @@ public class DiagnosticReadinessPacketTest {
 
     private void validateNonContinouslyMonitoredSystems2(String name, int index, int lowerByte, int upperByte,
             MonitoredSystemStatus status) {
-        int[] data = new int[] { 0, 0, 0, 0, 0, lowerByte, 0, upperByte };
-
-        DiagnosticReadinessPacket instance = createInstance(data);
+        DiagnosticReadinessPacket instance = createInstance(0, 0, 0, 0, 0, lowerByte, 0, upperByte);
 
         final List<MonitoredSystem> systems = instance.getNonContinuouslyMonitoredSystems();
         assertEquals(13, systems.size());

--- a/src/net/soliddesign/iumpr/bus/j1939/packets/DiagnosticReadinessPacket.java
+++ b/src/net/soliddesign/iumpr/bus/j1939/packets/DiagnosticReadinessPacket.java
@@ -17,9 +17,9 @@ import net.soliddesign.iumpr.bus.Packet;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
-public class DiagnosticReadinessPacket extends ParsedPacket {
+public abstract class DiagnosticReadinessPacket extends ParsedPacket {
 
-    public DiagnosticReadinessPacket(Packet packet) {
+    protected DiagnosticReadinessPacket(Packet packet) {
         super(packet);
     }
 
@@ -123,6 +123,15 @@ public class DiagnosticReadinessPacket extends ParsedPacket {
     }
 
     /**
+     * Helper method to indicate if this is a DM26 packet
+     *
+     * @return true if this is a DM26 packet
+     */
+    private boolean isDM26() {
+        return this instanceof DM26TripDiagnosticReadinessPacket;
+    }
+
+    /**
      * Helper method to indicate if this is a DM5 packet
      *
      * @return true if this is a DM5 packet
@@ -137,6 +146,6 @@ public class DiagnosticReadinessPacket extends ParsedPacket {
      * @return boolean
      */
     private boolean isOBDModule() {
-        return getByte(2) != (byte) 0x05 && getByte(2) != (byte) 0xFF;
+        return isDM26() || (isDM5() && getByte(2) != (byte) 0x05 && getByte(2) != (byte) 0xFF);
     }
 }


### PR DESCRIPTION
DiagnosticReadinessPacket is a super class for both the DM5 and DM26 packets.

In determining if a monitor is supported, the method isOBDModule() is used.  This looked at the value in the third byte of the DM5 message. But when calculated using a DM26 packet, the value returned from the method was wrong.  Actually it would only be wrong if the value in the third byte of a DM26 was 0x05 of 0xFF.

So isOBDModule() is fixed to return true if the packet is a DM26 packet or (DM5 and the the value is not 0x05 or 0xFF)

Additionally, I cleaned up the tests.  Since DiagnosticReadinessPacket is a super class for the DM5 and DM26 packets, I also made the DiagnosticReadnessPacketTest as super class for the DM5 and DM26 packet tests.  This allowed for removing duplicate tests.  The case "test0xFFWith0x05AsThirdByte()" in the DM26 Tests ensures this bug has been fixed.