### PR TITLE
Fix #74 and Fix #79

### DIFF
--- a/src-test/net/soliddesign/iumpr/modules/MonitorTrackingModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/MonitorTrackingModuleTest.java
@@ -397,22 +397,22 @@ public class MonitorTrackingModuleTest {
         expectedResults += "2007-12-03T10:15:30.000 Begin Tracking Monitor Completion Status" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM5 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FECE00 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FECE00 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM20 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18C20000 01 02 03 04 05 06 07 08 09 0A 0B" + NL;
+        expectedResults += "18C20000 01 02 03 04 05 06 07 08 09 0A 0B" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM26 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FDB800 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FDB800 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM5 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FECE00 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FECE00 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM20 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18C20000 01 02 03 04 05 06 07 08 09 0A 0B" + NL;
+        expectedResults += "18C20000 01 02 03 04 05 06 07 08 09 0A 0B" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM26 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FDB800 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FDB800 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "2007-12-03T10:15:30.000 End Tracking Monitor Completion Status. 36 Total Cycles." + NL;
 
@@ -673,13 +673,13 @@ public class MonitorTrackingModuleTest {
         expectedResults += "10:15:30.000 Ratios Updated" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM5 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FECE00 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FECE00 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM20 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18C20000 0B 0A 09 08 07 06 05 04 03 02 01" + NL;
+        expectedResults += "18C20000 0B 0A 09 08 07 06 05 04 03 02 01" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM26 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FDB800 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FDB800 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "2007-12-03T10:15:30.000 End Tracking Monitor Completion Status. 2 Total Cycles." + NL;
 
@@ -759,13 +759,13 @@ public class MonitorTrackingModuleTest {
         expectedResults += "10:15:30.000 Monitors Updated" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM5 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FECE00 08 07 06 05 04 03 02 01" + NL;
+        expectedResults += "18FECE00 08 07 06 05 04 03 02 01" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM20 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18C20000 01 02 03 04 05 06 07 08 09 0A 0B" + NL;
+        expectedResults += "18C20000 01 02 03 04 05 06 07 08 09 0A 0B" + NL;
         expectedResults += "" + NL;
         expectedResults += "10:15:30.000 DM26 Packet(s) Received" + NL;
-        expectedResults += "10:15:30.000 18FDB800 01 02 03 04 05 06 07 08" + NL;
+        expectedResults += "18FDB800 01 02 03 04 05 06 07 08" + NL;
         expectedResults += "" + NL;
         expectedResults += "2007-12-03T10:15:30.000 End Tracking Monitor Completion Status. 2 Total Cycles." + NL;
 

--- a/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -18,6 +20,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.junit.After;
 import org.junit.Before;
@@ -40,6 +44,7 @@ public class ReportFileModuleTest {
 
     private ReportFileModule instance;
     private TestResultsListener listener;
+    private Logger logger;
 
     @Before
     public void setUp() throws Exception {
@@ -47,12 +52,15 @@ public class ReportFileModuleTest {
         file.deleteOnExit();
         listener = new TestResultsListener();
 
-        instance = new ReportFileModule(new TestDateTimeModule() {
+        TestDateTimeModule dateTimeModule = new TestDateTimeModule() {
             @Override
             public DateTimeFormatter getTimeFormatter() {
                 return getSuperTimeFormatter();
             }
-        });
+        };
+
+        logger = mock(Logger.class);
+        instance = new ReportFileModule(dateTimeModule, logger);
     }
 
     @After
@@ -653,6 +661,9 @@ public class ReportFileModuleTest {
         assertEquals(1, instance.getInitialRatios().size());
         assertEquals(12, instance.getInitialIgnitionCycles());
         assertEquals(1, instance.getInitialOBDCounts());
+
+        verify(logger).log(Level.WARNING, "The dates in the file are inconsistent.");
+        verifyNoMoreInteractions(logger);
     }
 
     @Test

--- a/src-test/net/soliddesign/iumpr/system/SystemTest.java
+++ b/src-test/net/soliddesign/iumpr/system/SystemTest.java
@@ -91,22 +91,40 @@ public class SystemTest {
         DiagnosticReadinessModule diagnosticReadinessModule = new DiagnosticReadinessModule(dateTimeModule);
         EngineSpeedModule engineSpeedModule = new EngineSpeedModule();
         MonitorCompletionController monitorCompletionController = new MonitorCompletionController(scheduledThreadPool,
-                engineSpeedModule, new BannerModule(Type.MONITOR_LOG, dateTimeModule, buildNumber), dateTimeModule,
-                new VehicleInformationModule(dateTimeModule), diagnosticReadinessModule, new ComparisonModule(),
-                new MonitorTrackingModule(dateTimeModule, diagnosticReadinessModule, engineSpeedModule,
+                engineSpeedModule,
+                new BannerModule(Type.MONITOR_LOG, dateTimeModule, buildNumber),
+                dateTimeModule,
+                new VehicleInformationModule(dateTimeModule),
+                diagnosticReadinessModule,
+                new ComparisonModule(),
+                new MonitorTrackingModule(dateTimeModule,
+                        diagnosticReadinessModule,
+                        engineSpeedModule,
                         scheduledThreadPool));
 
         controller = new UserInterfaceController(view,
-                new DataPlateController(Executors.newSingleThreadScheduledExecutor(), new EngineSpeedModule(),
-                        new BannerModule(Type.DATA_PLATE, dateTimeModule, buildNumber), dateTimeModule,
-                        new VehicleInformationModule(dateTimeModule), new DiagnosticReadinessModule(dateTimeModule),
+                new DataPlateController(Executors.newSingleThreadScheduledExecutor(),
+                        new EngineSpeedModule(),
+                        new BannerModule(Type.DATA_PLATE, dateTimeModule, buildNumber),
+                        dateTimeModule,
+                        new VehicleInformationModule(dateTimeModule),
+                        new DiagnosticReadinessModule(dateTimeModule),
                         new DTCModule(dateTimeModule), new ComparisonModule()),
-                new CollectResultsController(Executors.newSingleThreadScheduledExecutor(), new EngineSpeedModule(),
-                        new BannerModule(Type.COLLECTION_LOG, dateTimeModule, buildNumber), dateTimeModule,
-                        new VehicleInformationModule(dateTimeModule), new DiagnosticReadinessModule(dateTimeModule),
-                        new OBDTestsModule(dateTimeModule), new ComparisonModule()),
-                monitorCompletionController, new ComparisonModule(), new RP1210(), new ReportFileModule(dateTimeModule),
-                Runtime.getRuntime(), Executors.newSingleThreadExecutor(), new HelpView());
+                new CollectResultsController(Executors.newSingleThreadScheduledExecutor(),
+                        new EngineSpeedModule(),
+                        new BannerModule(Type.COLLECTION_LOG, dateTimeModule, buildNumber),
+                        dateTimeModule,
+                        new VehicleInformationModule(dateTimeModule),
+                        new DiagnosticReadinessModule(dateTimeModule),
+                        new OBDTestsModule(dateTimeModule),
+                        new ComparisonModule()),
+                monitorCompletionController,
+                new ComparisonModule(),
+                new RP1210(),
+                new ReportFileModule(dateTimeModule, IUMPR.getLogger()),
+                Runtime.getRuntime(),
+                Executors.newSingleThreadExecutor(),
+                new HelpView());
     }
 
     @After

--- a/src/net/soliddesign/iumpr/modules/MonitorTrackingModule.java
+++ b/src/net/soliddesign/iumpr/modules/MonitorTrackingModule.java
@@ -427,7 +427,6 @@ public class MonitorTrackingModule extends FunctionalModule {
      *            the packets to write to the report
      */
     private void writePackets(ResultsListener listener, List<? extends ParsedPacket> packets) {
-        packets.stream().forEach(t -> listener
-                .onResult(t.getPacket().toString(getDateTimeModule().getTimeFormatter())));
+        packets.stream().forEach(t -> listener.onResult(t.getPacket().toString()));
     }
 }


### PR DESCRIPTION
Fix #74 - Don't write dates inconsistently and report to the log if they are written inconsistently.

Fix #79 - ReportModuleTest changed to verify that log was written if dates are inconsistent when writing to the log. MonitorCompletionModuleTest was changed to verify that dates are not written inconsistently