### PR TITLE
Mask DA when parsing report lines.

### DIFF
--- a/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/ReportFileModuleTest.java
@@ -71,6 +71,25 @@ public class ReportFileModuleTest {
     }
 
     @Test
+    public void testCalInfoBroadcast() throws Exception {
+        Writer writer = Files.newBufferedWriter(file.toPath(), StandardOpenOption.WRITE);
+        writer.write(
+                "2017-02-11T16:42:21.889 1CD3FF00 57 FD CF 54 35 52 32 30 33 31 30 30 41 30 30 30 30 30 30 30"
+                        + NL);
+        writer.write(
+                "2017-02-11T16:42:21.890 1CD3FF00 57 FD CF 54 35 52 32 30 33 31 30 30 41 30 30 30 30 30 30 30"
+                        + NL);
+        writer.write("  Time Since DTCs Cleared:                      14 minutes" + NL);
+        writer.write("2017-02-11T16:44:12.164 Vehicle Identification from Engine #1 (0): ASDFGHJKLASDFGHJKL" + NL);
+        writer.close();
+        try {
+            instance.setReportFile(listener, file, false);
+        } catch (ReportFileException e) {
+            assertEquals(Problem.MONITORS_NOT_PRESENT, e.getProblem());
+        }
+    }
+
+    @Test
     public void testCalInfoCanNotBeParsed() throws Exception {
         Writer writer = Files.newBufferedWriter(file.toPath(), StandardOpenOption.WRITE);
         writer.write(

--- a/src/net/soliddesign/iumpr/modules/ReportFileModule.java
+++ b/src/net/soliddesign/iumpr/modules/ReportFileModule.java
@@ -634,11 +634,17 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
     }
 
     private Packet parsePacket(int pgn, String line) {
-        if (line.contains(String.format("%04X", pgn))) {
+        String pattern = pgn >= 0xF000 ? String.format(".*%04X.*", pgn)
+                : String.format(".*(%04X|%04X|%04X).*", pgn | 0xFF, pgn & 0xFF00, (pgn & 0xFF00) | 0xF9);
+        if (line.matches(pattern)) {
             int index = line.indexOf(" ");
             String trimmedLine = line.substring(index + 1);
             Packet packet = Packet.parse(trimmedLine);
-            if (packet != null && packet.getId() == pgn) {
+            int id = packet.getId();
+            if (id < 0xF000) {
+                id &= 0xFF00;
+            }
+            if (packet != null && id == pgn) {
                 return packet;
             }
         }


### PR DESCRIPTION
When using TP, the TP session DA may not match the PGN.

For instance, the DM19 normally has a PGN of D300, but in one manufacturer's case, the "PGN" is D3FF.  This change accomodates that when reparsing the report for verification.