### PR TITLE
Fix #101 Fix #98

### DIFF
--- a/src-test/net/soliddesign/iumpr/modules/DateTimeModuleTest.java
+++ b/src-test/net/soliddesign/iumpr/modules/DateTimeModuleTest.java
@@ -25,7 +25,7 @@ public class DateTimeModuleTest {
 
     @Before
     public void setUp() {
-        instance = new DateTimeModule();
+        instance = DateTimeModule.getInstance();
     }
 
     @Test

--- a/src/net/soliddesign/iumpr/controllers/CollectResultsController.java
+++ b/src/net/soliddesign/iumpr/controllers/CollectResultsController.java
@@ -42,7 +42,7 @@ public class CollectResultsController extends Controller {
      */
     public CollectResultsController() {
         this(Executors.newSingleThreadScheduledExecutor(), new EngineSpeedModule(),
-                new BannerModule(Type.COLLECTION_LOG), new DateTimeModule(), new VehicleInformationModule(),
+                new BannerModule(Type.COLLECTION_LOG), DateTimeModule.getInstance(), new VehicleInformationModule(),
                 new DiagnosticReadinessModule(), new OBDTestsModule(), new ComparisonModule(),
                 new NoxBinningGhgTrackingModule());
     }

--- a/src/net/soliddesign/iumpr/controllers/DataPlateController.java
+++ b/src/net/soliddesign/iumpr/controllers/DataPlateController.java
@@ -41,7 +41,7 @@ public class DataPlateController extends Controller {
      */
     public DataPlateController() {
         this(Executors.newSingleThreadScheduledExecutor(), new EngineSpeedModule(), new BannerModule(Type.DATA_PLATE),
-                new DateTimeModule(), new VehicleInformationModule(), new DiagnosticReadinessModule(), new DTCModule(),
+                DateTimeModule.getInstance(), new VehicleInformationModule(), new DiagnosticReadinessModule(), new DTCModule(),
                 new ComparisonModule(), new NoxBinningGhgTrackingModule());
     }
 

--- a/src/net/soliddesign/iumpr/controllers/MonitorCompletionController.java
+++ b/src/net/soliddesign/iumpr/controllers/MonitorCompletionController.java
@@ -35,7 +35,7 @@ public class MonitorCompletionController extends Controller {
      */
     public MonitorCompletionController() {
         this(Executors.newScheduledThreadPool(2), new EngineSpeedModule(), new BannerModule(Type.MONITOR_LOG),
-                new DateTimeModule(), new VehicleInformationModule(), new DiagnosticReadinessModule(),
+                DateTimeModule.getInstance(), new VehicleInformationModule(), new DiagnosticReadinessModule(),
                 new ComparisonModule());
     }
 

--- a/src/net/soliddesign/iumpr/modules/BannerModule.java
+++ b/src/net/soliddesign/iumpr/modules/BannerModule.java
@@ -56,7 +56,7 @@ public class BannerModule extends FunctionalModule {
      *            the Report {@link Type} this banner will be for
      */
     public BannerModule(Type type) {
-        this(type, new DateTimeModule(), new BuildNumber());
+        this(type, DateTimeModule.getInstance(), new BuildNumber());
     }
 
     /**

--- a/src/net/soliddesign/iumpr/modules/ComparisonModule.java
+++ b/src/net/soliddesign/iumpr/modules/ComparisonModule.java
@@ -59,7 +59,7 @@ public class ComparisonModule extends FunctionalModule {
     private String vin;
 
     public ComparisonModule() {
-        super(new DateTimeModule());
+        super(DateTimeModule.getInstance());
     }
 
     /**

--- a/src/net/soliddesign/iumpr/modules/DTCModule.java
+++ b/src/net/soliddesign/iumpr/modules/DTCModule.java
@@ -39,7 +39,7 @@ public class DTCModule extends FunctionalModule {
      * Constructor
      */
     public DTCModule() {
-        this(new DateTimeModule());
+        this(DateTimeModule.getInstance());
     }
 
     /**

--- a/src/net/soliddesign/iumpr/modules/DiagnosticReadinessModule.java
+++ b/src/net/soliddesign/iumpr/modules/DiagnosticReadinessModule.java
@@ -334,19 +334,20 @@ public class DiagnosticReadinessModule extends FunctionalModule {
             if (packets.isEmpty()) {
                 listener.onResult(TIMEOUT_MESSAGE);
             } else {
-                for (ParsedPacket packet : packets) {
+                packets.stream().sorted((p1, p2) -> p1.getPacket().getTimestamp().compareTo(p2.getPacket().getTimestamp()))
+                        .forEach(packet -> {
                     listener.onResult(packet.getPacket().toTimeString());
                     if (fullString) {
                         listener.onResult(packet.toString());
                     }
-                }
+                });
             }
         }
         return packets;
     }
 
     /**
-     * Helper method to return the {@link Status} of the {@link MonitoredSystem}
+     * Helper method to return the status of the {@link MonitoredSystem}
      * padded with extra space on the right if necessary
      *
      * @param system

--- a/src/net/soliddesign/iumpr/modules/DiagnosticReadinessModule.java
+++ b/src/net/soliddesign/iumpr/modules/DiagnosticReadinessModule.java
@@ -165,7 +165,7 @@ public class DiagnosticReadinessModule extends FunctionalModule {
      * Constructor
      */
     public DiagnosticReadinessModule() {
-        this(new DateTimeModule());
+        this(DateTimeModule.getInstance());
     }
 
     /**

--- a/src/net/soliddesign/iumpr/modules/EngineSpeedModule.java
+++ b/src/net/soliddesign/iumpr/modules/EngineSpeedModule.java
@@ -19,7 +19,7 @@ import org.etools.j1939tools.modules.DateTimeModule;
 public class EngineSpeedModule extends FunctionalModule {
 
     public EngineSpeedModule() {
-        super(new DateTimeModule());
+        super(DateTimeModule.getInstance());
     }
 
     private EngineSpeedPacket getEngineSpeedPacket() {

--- a/src/net/soliddesign/iumpr/modules/NoxBinningGhgTrackingModule.java
+++ b/src/net/soliddesign/iumpr/modules/NoxBinningGhgTrackingModule.java
@@ -50,8 +50,8 @@ public class NoxBinningGhgTrackingModule extends FunctionalModule {
     private final NOxBinningModule nOxBinningModule;
 
     public NoxBinningGhgTrackingModule() {
-        this(new DateTimeModule(), new GhgTrackingModule(new DateTimeModule()),
-                new NOxBinningModule(new DateTimeModule()));
+        this(DateTimeModule.getInstance(), new GhgTrackingModule(DateTimeModule.getInstance()),
+                new NOxBinningModule(DateTimeModule.getInstance()));
     }
 
     public NoxBinningGhgTrackingModule(DateTimeModule dateTimeModule, GhgTrackingModule ghgTrackingModule,

--- a/src/net/soliddesign/iumpr/modules/OBDTestsModule.java
+++ b/src/net/soliddesign/iumpr/modules/OBDTestsModule.java
@@ -36,7 +36,7 @@ public class OBDTestsModule extends FunctionalModule {
      * Constructor
      */
     public OBDTestsModule() {
-        this(new DateTimeModule());
+        this(DateTimeModule.getInstance());
     }
 
     /**

--- a/src/net/soliddesign/iumpr/modules/ReportFileModule.java
+++ b/src/net/soliddesign/iumpr/modules/ReportFileModule.java
@@ -641,9 +641,12 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
         String pattern = pgn >= 0xF000 ? String.format(".*%04X.*", pgn)
                 : String.format(".*(%04X|%04X|%04X).*", pgn | 0xFF, pgn & 0xFF00, (pgn & 0xFF00) | 0xF9);
         if (line.matches(pattern)) {
-            int index = line.indexOf(" ");
-            String trimmedLine = line.substring(index + 1);
-            Packet packet = Packet.parse(trimmedLine);
+            //23:57:26.3390
+            if (line.matches(String.format("\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\d .*"))){
+                int index = line.indexOf(" ");
+                line = line.substring(index + 1);
+            }
+            Packet packet = Packet.parse(line);
             int id = packet.getId();
             if (id < 0xF000) {
                 id &= 0xFF00;

--- a/src/net/soliddesign/iumpr/modules/ReportFileModule.java
+++ b/src/net/soliddesign/iumpr/modules/ReportFileModule.java
@@ -15,6 +15,7 @@ import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -290,7 +291,7 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
                 dateCheckingOn = true;
             }
 
-            if (lastInstant != null && lineInstant.isBefore(lastInstant)) {
+            if (lastInstant != null && lineInstant.isBefore(lastInstant.minus(1, ChronoUnit.SECONDS))) {
                 if (dateCheckingOn) {
                     throw new ReportFileException(Problem.DATE_INCONSISTENT);
                 } else {

--- a/src/net/soliddesign/iumpr/modules/ReportFileModule.java
+++ b/src/net/soliddesign/iumpr/modules/ReportFileModule.java
@@ -223,7 +223,7 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
      * Constructor
      */
     public ReportFileModule() {
-        this(new DateTimeModule(), IUMPR.getLogger());
+        this(DateTimeModule.getInstance(), IUMPR.getLogger());
     }
 
     /**
@@ -641,8 +641,7 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
         String pattern = pgn >= 0xF000 ? String.format(".*%04X.*", pgn)
                 : String.format(".*(%04X|%04X|%04X).*", pgn | 0xFF, pgn & 0xFF00, (pgn & 0xFF00) | 0xF9);
         if (line.matches(pattern)) {
-            //23:57:26.3390
-            if (line.matches(String.format("\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\d .*"))){
+            if (line.matches(String.format(".*\\d\\d:\\d\\d:\\d\\d\\.\\d* .*"))){
                 int index = line.indexOf(" ");
                 line = line.substring(index + 1);
             }

--- a/src/net/soliddesign/iumpr/modules/VehicleInformationModule.java
+++ b/src/net/soliddesign/iumpr/modules/VehicleInformationModule.java
@@ -38,7 +38,7 @@ public class VehicleInformationModule extends FunctionalModule {
      * Constructor
      */
     public VehicleInformationModule() {
-        this(new DateTimeModule());
+        this(DateTimeModule.getInstance());
     }
 
     /**

--- a/src/org/etools/j1939tools/modules/DateTimeModule.java
+++ b/src/org/etools/j1939tools/modules/DateTimeModule.java
@@ -52,7 +52,7 @@ public class DateTimeModule {
 
     private DateTimeFormatter timeFormatter;
 
-    public DateTimeModule() {
+    protected DateTimeModule() {
     }
 
     /**
@@ -90,7 +90,7 @@ public class DateTimeModule {
      * Formats the given {@link TemporalAccessor} as a {@link String} which
      * includes only the Time
      *
-     * @param dateTime
+     * @param time
      *            the {@link TemporalAccessor} to format
      * @return {@link String}
      * @throws DateTimeException


### PR DESCRIPTION
@battjt 

- uses single DateTimeModule instance
- allow 1 sec when checking timestamps
- report a list of DM5s etc. collected together in chronological order
- parse packets from report file even if line doesn't have a timestamp (no effect on bug, but reduces false error messages in logs)